### PR TITLE
Re-order groupby and orderby statements in FluentQueryBuilder

### DIFF
--- a/src/DapperQueryBuilder/FluentQueryBuilder/FluentQueryBuilder.cs
+++ b/src/DapperQueryBuilder/FluentQueryBuilder/FluentQueryBuilder.cs
@@ -205,12 +205,12 @@ namespace DapperQueryBuilder
                 if (filters != null)
                     finalSql.AppendLine("WHERE " + filters);
 
-                if (_orderBy.Any())
-                    finalSql.AppendLine($"ORDER BY {string.Join(", ", _orderBy)}");
                 if (_groupBy.Any())
                     finalSql.AppendLine($"GROUP BY {string.Join(", ", _groupBy)}");
                 if (_having.Any())
                     finalSql.AppendLine($"HAVING {string.Join(" AND ", _having)}");
+                if (_orderBy.Any())
+                    finalSql.AppendLine($"ORDER BY {string.Join(", ", _orderBy)}");
                 if (_rowCount != null)
                     finalSql.AppendLine($"OFFSET {_offset ?? 0} ROWS FETCH NEXT {_rowCount} ROWS ONLY"); // TODO: PostgreSQL? "LIMIT row_count OFFSET offset"
 


### PR DESCRIPTION
Building a SQL query using the FluentQueryBuilder with both a GroupBy and an OrderBy-statement results in invalid SQL as the OrderBy appears before GroupBy. This PR fixes that by re-arranging the appending to the final SQL generated.
A unit test has been created to test this. However, it is not easily possible to run your unit tests locally as they rely on some SQL database that you probably have on your machine.