### PR TITLE
Fixes #7 to merge parameter names correctly

### DIFF
--- a/src/DapperQueryBuilder/ParameterInfos.cs
+++ b/src/DapperQueryBuilder/ParameterInfos.cs
@@ -137,10 +137,10 @@ namespace DapperQueryBuilder
             {
                 string newParameterName = MergeParameter(parameter);
                 if (newParameterName != null)
-                    newSql = newSql.Replace("@" + parameter.Name, "@" + newParameterName);
+                    newSql = newSql.Replace("@" + parameter.Name, "DQB:@:DBQ" + newParameterName);
             }
             if (newSql != sql)
-                return newSql;
+                return newSql.Replace( "DQB:@:DBQ", "@" );
             return null;
         }
 


### PR DESCRIPTION
Probably someone smarter has a better way to do it, but to solve the parameter names getting dinged up, I simply added a temporary string during parameter name substitution that prevents it from being mistakenly replaced on subsequent parameter renames.

Then the last return removes this temporary string (`DQB:@:DBQ`)

Note, my Feature/reuse parameters pull request also includes this fix.