### PR TITLE
Allow :raw to work for any type (including null)

### DIFF
--- a/src/DapperQueryBuilder/InterpolatedStatementParser.cs
+++ b/src/DapperQueryBuilder/InterpolatedStatementParser.cs
@@ -120,7 +120,7 @@ namespace DapperQueryBuilder
                 List<string> argFormats = argFormat.Split(new char[] { ',', '|' }, StringSplitOptions.RemoveEmptyEntries).Select(f => f.Trim()).ToList();
                 object arg = arguments[argPos];
 
-                if (arg is string && argFormats.Contains("raw")) // example: {nameof(Product.Name):raw}  -> won't be parametrized, we just emit raw string!
+                if (argFormats.Contains("raw")) // example: {nameof(Product.Name):raw}  -> won't be parametrized, we just emit raw string!
                 {
                     sb.Append(sql);
                     sb.Append(arg);


### PR DESCRIPTION
I ran into a couple `:raw` format issues.

**Numbers**

```
var backupFileLength = backupFileName?.Length ?? 1;

var qb = cnStreamComplete.QueryBuilder( $@"
DECLARE @fKey int; SET @fKey = {fileId};
DECLARE @backupFileName VARCHAR({backupFileLength:raw}); SET @backupFileName = {backupFileName};
```

I needed to dynamically declare the length of a param.  I made it work originally by using `.ToString():raw`, but the next problem prompted me to fix it.

**null string**

I was dynamically adding an order by...

```
		protected QueryBuilder GetFileInfoWithAllVersionsTemplateQueryBuilder( IDbConnection cn, string version, string orderBy )
		{
			var qb = cn.QueryBuilder( $@"
{FileInfoSelect( !string.IsNullOrEmpty( orderBy ) ? 1 : null ):raw}

FROM Version v
	INNER JOIN [File] f ON v.[File] = f.UID
	INNER JOIN Folder fo on f.Folder = fo.UID

WHERE ( {version} IS NULL OR v.VersionID = {version} ) /**filters**/

{orderBy:raw}" );

			return qb;
		}
```

If I passed in `null` for orderBy, it still injected a `@p` string parameter which isn't what I wanted.

**Fix**

Simply changed this line to remove the `is string` check:

`if (argFormats.Contains("raw")) // example: {nameof(Product.Name):raw}  -> won't be parametrized, we just emit raw string!`

I'll merge this into my **reuse-parameters** branch as well.