### PR TITLE
Interpolated Statement Adapter

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -348,3 +348,4 @@ MigrationBackup/
 
 # Ionide (cross platform F# VS Code tools) working folder
 .ionide/
+/src/DapperQueryBuilder/DapperQueryBuilder.xml

--- a/src/DapperQueryBuilder.Tests/QueryBuilderTests.cs
+++ b/src/DapperQueryBuilder.Tests/QueryBuilderTests.cs
@@ -102,6 +102,19 @@ ORDER BY ProductId
             Assert.AreEqual(@"WHERE ([ListPrice] >= @p0 AND [ListPrice] <= @p1) AND ([Weight] <= @p2 OR [Name] LIKE @p3)", where);
         }
 
+        [Test]
+        public void TestQueryBuilderParameterizedConstructor()
+        {
+            bool useTableA = false;
 
+            var query = cn.QueryBuilder($"SELECT * FROM {(useTableA ? "TableA" : "TableB")} WHERE SomeColumn=@someParam", new { someParam = "someParamValue" });
+
+            Assert.AreEqual("SELECT * FROM TableB WHERE SomeColumn=@p0", query.Sql);
+            Assert.AreEqual(1, query.Parameters.Count);
+
+            var param = query.Parameters.First().Value;
+            Assert.AreEqual("p0", param.Name);
+            Assert.AreEqual("someParamValue", param.Value);
+        }
     }
 }

--- a/src/DapperQueryBuilder/IDbConnectionExtensions.cs
+++ b/src/DapperQueryBuilder/IDbConnectionExtensions.cs
@@ -33,6 +33,19 @@ namespace DapperQueryBuilder
         }
 
         /// <summary>
+        /// Creates a new QueryBuilder over current connection
+        /// </summary>
+        /// <param name="cnn"></param>
+        /// <param name="sql">You can use "{where}" or "/**where**/" in your query, and it will be replaced by "WHERE + filters" (if any filter is defined). <br />
+        /// You can use "{filters}" or "/**filters**/" in your query, and it will be replaced by "filters" (without where) (if any filter is defined).
+        /// </param>
+        /// <param name="parameters">Anonymous object containing any parameters referenced in the SQL query. Can be null.</param>
+        public static QueryBuilder QueryBuilder(this IDbConnection cnn, string sql, object parameters)
+        {
+            return new QueryBuilder(cnn, sql, parameters);
+        }
+
+        /// <summary>
         /// Creates a new empty QueryBuilder over current connection
         /// </summary>
         /// <param name="cnn"></param>

--- a/src/DapperQueryBuilder/InterpolatedStatementAdapter.cs
+++ b/src/DapperQueryBuilder/InterpolatedStatementAdapter.cs
@@ -1,0 +1,105 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Text;
+using System.Text.RegularExpressions;
+
+namespace DapperQueryBuilder
+{
+	/// <summary>
+	/// An adapter class that allows a normal SQL string and parameters object
+	/// to be used by the DapperQueryBuilder.QueryBuilder constructor instead
+	/// of a plain formattable string. This allows the initial SQL template to be
+	/// constructed using string interpolation.
+	/// </summary>
+	public class InterpolatedStatementAdapter : FormattableString
+	{
+		readonly string _originalSql;
+		readonly string _sql;
+		readonly object[] _arguments;
+		static readonly Regex _regex = new Regex(@"(@[a-z0-9_]+)", RegexOptions.Compiled | RegexOptions.IgnoreCase);
+
+		/// <summary>
+		/// Instantiate an formattable string by replacing parameters
+		/// </summary>
+		/// <param name="sql"></param>
+		/// <param name="parameters"></param>
+		public InterpolatedStatementAdapter(string sql, object parameters)
+		{
+			_originalSql = sql;
+
+			//Convert parameters object to indexed object array
+			var paramDict = ToDictionary(parameters);
+			_arguments = new object[paramDict.Keys.Count];
+			var map = new Dictionary<string, int>();
+			int idx = 0;
+			foreach (string key in paramDict.Keys)
+			{
+				_arguments[idx] = paramDict[key];
+				map[key] = idx;
+				idx++;
+			}
+
+			//Convert SQL to formattable string
+			_sql = _regex.Replace(sql, m =>
+			{
+				string paramName = m.Value.Substring(1);
+
+				if (!map.ContainsKey(paramName))
+					throw new Exception($"Parameter {paramName} not supplied");
+
+				return "{" + map[paramName] + "}";
+			});
+		}
+
+        #region FormattableString implementation
+        /// <summary>
+        /// Gets the number of arguments to be formatted.
+        /// </summary>
+        public override int ArgumentCount => _arguments.Length;
+		/// <summary>
+		/// Gets the original SQL statement
+		/// </summary>
+		public override string Format => _sql;
+		/// <summary>
+		/// Returns the argument at the specified index position.
+		/// </summary>
+		/// <param name="index">The index of the argument. Its value can range from zero to one less than the value of System.FormattableString.ArgumentCount.</param>
+		/// <returns>The argument.</returns>
+		public override object GetArgument(int index) => _arguments[index];
+		/// <summary>
+		/// Returns an object array that contains one or more objects to format.
+		/// </summary>
+		/// <returns>n object array that contains one or more objects to format.</returns>
+		public override object[] GetArguments() => _arguments;
+		/// <summary>
+		/// Returns the original SQL statement
+		/// </summary>
+		/// <param name="formatProvider"></param>
+		/// <returns>The original SQL statement</returns>
+		public override string ToString(IFormatProvider formatProvider) => _originalSql;
+		/// <summary>
+		/// Returns the original SQL statement
+		/// </summary>
+		/// <returns>The original SQL statement</returns>
+		public override string ToString() => _originalSql;
+        #endregion
+
+        static Dictionary<string, object> ToDictionary(object o)
+		{
+			var dictionary = new Dictionary<string, object>();
+
+			if (o != null)
+			{
+				foreach (var propertyInfo in o.GetType().GetProperties())
+				{
+					if (propertyInfo.GetIndexParameters().Length == 0)
+					{
+						dictionary.Add(propertyInfo.Name, propertyInfo.GetValue(o, null));
+					}
+				}
+			}
+
+			return dictionary;
+		}
+	}
+}

--- a/src/DapperQueryBuilder/QueryBuilder.cs
+++ b/src/DapperQueryBuilder/QueryBuilder.cs
@@ -60,6 +60,22 @@ namespace DapperQueryBuilder
         {
             _commandBuilder = new CommandBuilder(cnn, query);
         }
+
+        /// <summary>
+        /// New QueryBuilder based on an initial parameterized query. <br />
+        /// Query can be modified using .Append(), .AppendLine(), .Where(). <br />
+        /// Parameters should be referenced Dapper-style prefixed with the "@" symbol.
+        /// Where filters will later replace /**where**/ keyword
+        /// </summary>
+        /// <param name="cnn"></param>
+        /// <param name="sql">You can use "{where}" or "/**where**/" in your query, and it will be replaced by "WHERE + filters" (if any filter is defined). <br />
+        /// You can use "{filters}" or "/**filters**/" in your query, and it will be replaced by "AND filters" (without where) (if any filter is defined).
+        /// </param>
+        /// <param name="parameters">Anonymous object containing any parameters referenced in the SQL query. Can be null.</param>
+        public QueryBuilder(IDbConnection cnn, string sql, object parameters)
+        {
+            _commandBuilder = new CommandBuilder(cnn, new InterpolatedStatementAdapter(sql, parameters));
+        }
         #endregion
 
         #region Filters/Where


### PR DESCRIPTION
Using native Dapper, I frequently construct the initial SQL statement using conditional logic, which may involve string.Format(), string interpolation (for SQL, not parameters), or string concatenation. The QueryBuilder accepting a FormattableString will not accept such constructed SQL. 

This InterpolatedStatementAdapter turns a plain string SQL statement, plus a parameters object, into a FormattableString that's usable in the QueryBuilder.