### PR TITLE
adds GroupBy to IFromBuilder

### DIFF
--- a/src/DapperQueryBuilder.Tests/FluentQueryBuilderTests.cs
+++ b/src/DapperQueryBuilder.Tests/FluentQueryBuilderTests.cs
@@ -273,7 +273,34 @@ ORDER BY cat.[Name]
 
         }
 
+        [Test]
+        public void GroupByWithNoWhereTest()
+        {
+            var q = cn.FluentQueryBuilder()
+                .Select($"cat.[Name] as [Category]")
+                .Select($"AVG(p.[ListPrice]) as [AveragePrice]")
+                .From($"[Production].[Product] p")
+                .From($"LEFT JOIN [Production].[ProductSubcategory] sc ON p.[ProductSubcategoryID]=sc.[ProductSubcategoryID]")
+                .From($"LEFT JOIN [Production].[ProductCategory] cat on sc.[ProductCategoryID]=cat.[ProductCategoryID]")
+                .GroupBy($"cat.[Name]")
+                .Having($"COUNT(*)>{5}");
 
+            string expected =
+                @"SELECT cat.[Name] as [Category], AVG(p.[ListPrice]) as [AveragePrice]
+FROM [Production].[Product] p
+LEFT JOIN [Production].[ProductSubcategory] sc ON p.[ProductSubcategoryID]=sc.[ProductSubcategoryID]
+LEFT JOIN [Production].[ProductCategory] cat on sc.[ProductCategoryID]=cat.[ProductCategoryID]
+GROUP BY cat.[Name]
+HAVING COUNT(*)>@p0
+";
+
+            Assert.AreEqual(expected, q.Sql);
+
+            var results = q.Query();
+
+            Assert.That(results.Any());
+
+        }
 
         [Test]
         public void FluentQueryBuilderInsideCommandBuilder()

--- a/src/DapperQueryBuilder/FluentQueryBuilder/IFromBuilder.cs
+++ b/src/DapperQueryBuilder/FluentQueryBuilder/IFromBuilder.cs
@@ -10,6 +10,16 @@ namespace DapperQueryBuilder
     public interface IFromBuilder : ICompleteCommand
     {
         /// <summary>
+        /// Adds one column to the select clauses
+        /// </summary>
+        ISelectBuilder Select(FormattableString column);
+
+        /// <summary>
+        /// Adds one or more columns to the select clauses
+        /// </summary>
+        ISelectBuilder Select(params FormattableString[] moreColumns);
+
+        /// <summary>
         /// Adds a new table to from clauses. <br />
         /// "FROM" word is optional. <br />
         /// You can add an alias after table name. <br />

--- a/src/DapperQueryBuilder/FluentQueryBuilder/IFromBuilder.cs
+++ b/src/DapperQueryBuilder/FluentQueryBuilder/IFromBuilder.cs
@@ -34,6 +34,11 @@ namespace DapperQueryBuilder
         IWhereBuilder Where(FormattableString filter);
 
         /// <summary>
+        /// Adds a new condition to groupby clauses.
+        /// </summary>
+        IGroupByBuilder GroupBy(FormattableString groupBy);
+
+        /// <summary>
         /// Adds one or more column(s) to orderby clauses.
         /// </summary>
         IOrderByBuilder OrderBy(FormattableString orderBy);


### PR DESCRIPTION
Currently its not possible to add a GroupBy with the FluentQueryBuilder unless there is a WHERE clause. This change allows chaining the GroupBy off the IFromBuilder.